### PR TITLE
One singular line I messed up

### DIFF
--- a/src/packet.rs
+++ b/src/packet.rs
@@ -24,7 +24,7 @@ impl Packet {
 
     pub fn from_bytes(bytes: &[u8]) -> Self {
         let header_bytes = &bytes[0..14];
-        let header = Header::try_from(header_bytes).unwrap();
+        let header = Header::try_from(header_bytes).unwrap(); // TODO forgot this mf when i made header::from_bytes in to 'try_from'
         let mut start_index: usize = 10;
         if header.packet_type.timecode{
             start_index = 14;

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -24,7 +24,7 @@ impl Packet {
 
     pub fn from_bytes(bytes: &[u8]) -> Self {
         let header_bytes = &bytes[0..14];
-        let header = Header::try_from(header_bytes).unwrap(); // TODO forgot this mf when i made header::from_bytes in to 'try_from'
+        let header = Header::from(header_bytes);
         let mut start_index: usize = 10;
         if header.packet_type.timecode{
             start_index = 14;


### PR DESCRIPTION
I had at some point turned the `Header`'s `from` `[u8]` function into a `try_from` `[u8]` (fallible), but ended up reversing this and making it infallible again. Unfortunately, while I remembered to change this call to the new `try_from` (and added a temporary `.unwrap()`), I forgot to change it back, and the `try_from` was automatically implemented from the `from` function, so the compiler was happy. This is not as critical as I thought when I committed the fix, but probably still worth fixing.